### PR TITLE
Add prepared statement

### DIFF
--- a/sprockets/clients/cassandra/__init__.py
+++ b/sprockets/clients/cassandra/__init__.py
@@ -112,9 +112,8 @@ class CassandraConnection(object):
         keyword arguments. See cassandra-python documentation for
         definition of those parameters.
         """
-        stmt = CassandraConnection._prepared_statement_cache.get(query, query)
         tornado_future = Future()
-        cassandra_future = self._session.execute_async(stmt, *args, **kwargs)
+        cassandra_future = self._session.execute_async(query, *args, **kwargs)
         self._ioloop.add_callback(
             self._callback, cassandra_future, tornado_future)
         return tornado_future

--- a/tests.py
+++ b/tests.py
@@ -74,5 +74,5 @@ class TestCassandraConnectionClass(AsyncTestCase):
         stmt = self.connection.prepare('SELECT * FROM names;', 'get_names')
         copy = self.connection.prepare('SELECT * FROM names;', 'get_names')
         self.assertIs(stmt, copy, 'Should return the cached statement')
-        results = yield self.connection.execute('get_names')
+        results = yield self.connection.execute(stmt)
         self.assertEqual(results[0].name, 'Peabody')


### PR DESCRIPTION
This PR adds some magic around preparing statements.  We can now delegate a call to the connection object to do a prepare for use and we can cache the result, so multiple calls to `prepare` won't incur additional network overhead.
